### PR TITLE
feat:支持 query 参数配置搜索关键词与包含/排除过滤项

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,6 +18,8 @@ import { getDiskTypeName } from '@/utils/diskTypes';
 
 // 后端健康状态缓存（应用启动时获取一次）
 const backendHealth = ref<HealthStatus | null>(null);
+// 健康状态是否已获取完毕（无论成功或失败），SearchForm 依赖它决定何时按 URL 参数自动搜索
+const healthReady = ref(false);
 
 // 搜索状态
 const loading = ref(false);
@@ -150,6 +152,9 @@ const initBackendHealth = async () => {
   } catch (err) {
     console.error('获取后端健康状态失败:', err);
     backendHealth.value = null;
+  } finally {
+    // 失败时也要放行，让自动搜索走与手动搜索相同的兜底路径，不会永久卡住
+    healthReady.value = true;
   }
 };
 
@@ -1288,9 +1293,10 @@ onUnmounted(() => {
       <div v-if="currentPage === 'search'" class="search-page">
         <!-- 搜索表单 -->
         <div class="search-form-block mb-6">
-          <SearchForm 
+          <SearchForm
             :backend-health="backendHealth"
-            @search="handleSearch" 
+            :health-ready="healthReady"
+            @search="handleSearch"
             @search-complete="handleSearchComplete"
           />
         </div>

--- a/src/components/SearchForm.vue
+++ b/src/components/SearchForm.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, onMounted, watch } from 'vue';
 import type { SearchParams } from '@/api';
 import type { HealthStatus } from '@/api';
 import type { FilterConfig } from '@/types';
 import { Button, Input, Icons } from '@/components/ui';
 import FilterIcon from '@/components/icons/FilterIcon.vue';
+import { parseSearchQuery, writeSearchQuery } from '@/utils/searchQuery';
 
 const keyword = ref('');
 const loading = ref(false);
@@ -12,9 +13,14 @@ const showAdvanced = ref(false);
 const includeKeywords = ref('');
 const excludeKeywords = ref('');
 
+// 是否已根据 URL 参数自动搜索过（避免重复触发）
+const autoSearched = ref(false);
+
 // 接收后端健康状态作为 props
 const props = defineProps<{
   backendHealth: HealthStatus | null;
+  // 后端健康状态是否已获取完毕（成功或失败），用于决定何时可以自动搜索
+  healthReady?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -122,7 +128,14 @@ const handleSearch = () => {
   if (filterConfig.include || filterConfig.exclude) {
     (params as any).filter = JSON.stringify(filterConfig);
   }
-  
+
+  // 把当前搜索条件同步到地址栏，方便复制分享和刷新保留
+  writeSearchQuery({
+    keyword: keyword.value,
+    include: includeKeywords.value,
+    exclude: excludeKeywords.value
+  });
+
   emit('search', params);
   
   // 2秒后重置loading状态
@@ -131,6 +144,33 @@ const handleSearch = () => {
     // 不再触发searchComplete事件
   }, 2000);
 };
+
+// 从 URL 读取搜索条件并填入表单
+onMounted(() => {
+  const query = parseSearchQuery();
+
+  keyword.value = query.keyword;
+  includeKeywords.value = query.include;
+  excludeKeywords.value = query.exclude;
+
+  // 带了过滤条件时展开高级面板，让生效的过滤项可见
+  if (query.include || query.exclude) {
+    showAdvanced.value = true;
+  }
+});
+
+// 自动搜索要等后端健康状态就绪：子组件 onMounted 早于父组件，
+// 此时 backendHealth 必然为 null，直接搜索会让未配置过的用户拿到与手动搜索不同的结果。
+// healthReady 在应用生命周期内只会 false -> true 一次，且必然晚于本组件首次挂载，
+// 因此这里不需要 immediate；切换页面后重新挂载时也不会重复搜索
+watch(() => props.healthReady, (ready) => {
+  if (!ready || autoSearched.value || !keyword.value.trim()) {
+    return;
+  }
+
+  autoSearched.value = true;
+  handleSearch();
+});
 </script>
 
 <template>

--- a/src/utils/searchQuery.ts
+++ b/src/utils/searchQuery.ts
@@ -1,0 +1,66 @@
+// URL query 参数与搜索条件的互相转换
+// q   -> 搜索关键词
+// inc -> 包含关键词（OR关系）
+// exc -> 排除关键词（OR关系）
+// 示例: ?q=流浪地球&inc=4k,hdr&exc=预告
+
+const KEYWORD_PARAM = 'q';
+const INCLUDE_PARAM = 'inc';
+const EXCLUDE_PARAM = 'exc';
+
+// 与 SearchForm 中的过滤逻辑保持一致：空格或英文逗号分隔
+const KEYWORD_SEPARATOR = /[,\s]+/;
+
+export interface SearchQueryState {
+  keyword: string;
+  include: string;
+  exclude: string;
+}
+
+// 归一化为逗号分隔，避免回写后地址栏出现 + 或 %20
+const normalizeKeywords = (value: string) => {
+  return value.split(KEYWORD_SEPARATOR).filter(k => k.trim()).join(',');
+};
+
+// 从 URL 读取搜索条件。原始字符串直接返回，不做拆分，
+// 这样手写的 inc=4k%20hdr（空格分隔）也能被输入框正常识别
+export const parseSearchQuery = (search: string = window.location.search): SearchQueryState => {
+  const params = new URLSearchParams(search);
+
+  return {
+    keyword: (params.get(KEYWORD_PARAM) || '').trim(),
+    include: (params.get(INCLUDE_PARAM) || '').trim(),
+    exclude: (params.get(EXCLUDE_PARAM) || '').trim()
+  };
+};
+
+// 把当前搜索条件写回地址栏（不产生历史记录）
+export const writeSearchQuery = (state: SearchQueryState) => {
+  const params = new URLSearchParams();
+
+  const keyword = state.keyword.trim();
+  const include = normalizeKeywords(state.include);
+  const exclude = normalizeKeywords(state.exclude);
+
+  if (keyword) {
+    params.set(KEYWORD_PARAM, keyword);
+  }
+  if (include) {
+    params.set(INCLUDE_PARAM, include);
+  }
+  if (exclude) {
+    params.set(EXCLUDE_PARAM, exclude);
+  }
+
+  // 逗号是合法的 query 字符，还原回来让链接更易读
+  const query = params.toString().replace(/%2C/g, ',');
+  const url = query
+    ? `${window.location.pathname}?${query}${window.location.hash}`
+    : `${window.location.pathname}${window.location.hash}`;
+
+  try {
+    window.history.replaceState(window.history.state, '', url);
+  } catch (err) {
+    console.error('更新地址栏失败:', err);
+  }
+};


### PR DESCRIPTION
## 背景

目前搜索关键词和「包含关键词」「排除关键词」两个过滤项都只存在于组件内部状态，既没法通过链接分享一次搜索，刷新页面后条件也全部丢失。

## 改动

新增三个 URL query 参数：

| 参数 | 含义 | 示例 |
| --- | --- | --- |
| `q` | 搜索关键词 | `q=流浪地球` |
| `inc` | 包含关键词，OR 关系 | `inc=4k,hdr` |
| `exc` | 排除关键词，OR 关系 | `exc=预告,花絮` |

完整示例：`?q=流浪地球&inc=4k,hdr&exc=预告`

行为：

- **读入**：打开带参数的链接会自动填好搜索框；带了 `inc` / `exc` 时顺手展开高级筛选面板，让生效的过滤条件可见；`q` 非空时自动发起搜索。
- **回写**：页面内每次搜索后把当前条件同步到地址栏，可直接复制分享，刷新也能保留。
- 多关键词用英文逗号分隔。解析时不拆分、原始字符串直接填进输入框，所以手写的 `inc=4k%20hdr`（空格分隔）同样可用——输入框本来就按 `/[,\s]+/` 拆分。回写时统一归一化为逗号分隔，避免地址栏出现 `+` / `%20`。
- 空值不写入对应参数，三项全空时清掉整个 query。
- 用 `replaceState`，搜索不会堆积浏览器历史记录，不至于搜十次要按十次后退。

## 文件

- `src/utils/searchQuery.ts`（新增）：`parseSearchQuery()` / `writeSearchQuery()` 两个纯函数，不依赖 Vue。
- `src/components/SearchForm.vue`：`onMounted` 读 URL 填表单；`handleSearch` 内 `emit` 之前回写地址栏。手动搜索、回车搜索、URL 自动搜索共用这一条路径，地址栏与实际搜索条件天然一致。
- `src/App.vue`：新增 `healthReady`，作为 prop 传给 `SearchForm`。

## 一个时序上的坑

自动搜索没有放在 `onMounted`，而是等 `healthReady`。

Vue 中子组件 `onMounted` 早于父组件，而 `backendHealth` 要等 `App.vue` 的 `onMounted` 里 `await getHealth()` 之后才有值。`SearchForm` 挂载那一刻 `props.backendHealth` 必然是 `null`，对没有 localStorage 配置的新用户，`loadUserConfig()` 会返回空 channels/plugins，`src` 退化成 `all` 且不带 channels / plugins 参数，自动搜索的结果会和手动点搜索不一样。

因此 `initBackendHealth()` 在 `finally` 里把 `healthReady` 置 true（成功或失败都置，失败时走与手动搜索完全相同的兜底路径，不会永久卡住），`SearchForm` 监听它来触发唯一一次自动搜索。

## 不做

- 不用 `pushState`，因此不需要监听 `popstate`、也不涉及与进行中搜索的竞态。
- 频道 / 插件 / 网盘类型等配置仍由 localStorage 管理，不进 URL。

## 验证

项目没有测试框架，在本地 dev server 配一个会记录请求参数的 mock 后端，逐条手工验证：

| 场景 | 结果 |
| --- | --- |
| `?q=流浪地球&inc=4k,hdr&exc=预告,花絮` | 输入框填好、面板展开、tag 正确，请求带 `filter={"include":["4k","hdr"],"exclude":["预告","花絮"]}` 及 channels / plugins |
| `?q=流浪地球&inc=4k%20hdr%20,,&exc=` | 地址栏归一化为 `?q=流浪地球&inc=4k,hdr`，空的 `exc` 被移除 |
| 手动改关键词、清空包含、填入排除后回车 | 地址栏变 `?q=沙丘&exc=预告,枪版`，`inc` 消失 |
| 按浏览器后退 | 无历史条目，`replaceState` 生效 |
| `?inc=4k&exc=预告`（无 `q`） | 填表单 + 展开面板，不发搜索请求 |
| 无 query 打开首页 | 地址栏不变、无请求，与改动前一致 |

`npm run build` 通过。控制台无本项目报错。

`tsc --noEmit` 有两条 `src/api/index.ts:109` 的报错，`git stash` 对比确认改动前就已存在，与本 PR 无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
